### PR TITLE
Don't use non LTS version of node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,17 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [19.x]
-
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
 
       - name: Install dependencies & build
         run: |


### PR DESCRIPTION
It's recommended to stay off the odd major versions of Node as the ecosystem is often not ready to work with it. So let's use the latest 18 version.

Also, a strategy only makes sense if you're going to test against several versions. By removing it, it will also save one click when viewing the workflow in Github's UI.