### PR TITLE
Update i18n.js (localization correction for RU string)

### DIFF
--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -750,7 +750,7 @@ export default {
     highlight: {
       fr: "Surligner ce talent",
       en: "Highlight this talent",
-      ru: "Подсветить Таланты",
+      ru: "Подсветить талант",
     },
   },
   ambitions: {


### PR DESCRIPTION
Realized that it was my mistake with RU locale string for highlighting talents.
It should be a bit different to look consistent with other highlight strings.