### PR TITLE
Update i18n.js

### DIFF
--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -549,7 +549,7 @@ export default {
         label: {
           fr: "Corps à corps (base)",
           en: "Melee (Basic)",
-          ru: "Рукопашный бой (основное)",
+          ru: "Рукопашный бой (осн.)",
         },
       },
       {


### PR DESCRIPTION
Found that the second section of Basic skills in russian localization has horizontal scrolling and that is why user can't see skill name and value at one time (you need to scroll to check the values).
The string "Melee (Basic)" looks the longest one for this section so I've shortened the word "основной", hope it will help to exclude horizontal scrolling at all.