### PR TITLE
fix: Allow multiple of Hardy talent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2025-04-30
+
+### Fixed
+
+- Changing a custom skill characteristic's base now displays the right output.
+- Change Hardy talent in Wounds section from a checkbox to an input for users buying multiple levels of the talent.
+
 ## [2.1.0] - 2025-04-10
 
 ### Added

--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
   const characSelects = document.querySelectorAll(".charac-select");
   const bonuses = document.querySelectorAll("output.bonus");
   const customData = document.querySelectorAll(".custom");
-  const toggleHardy = document.getElementById("hardy-bonus");
+  const hardyTalent = document.getElementById("hardy-bonus");
   const speciesSelect = document.getElementById("species");
   const encumbranceSrc = document.querySelectorAll(".encumbrance-src");
   const encumbranceMax = document.getElementById("encumbrance-max");
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
   customData.forEach((custom) => {
     custom.addEventListener("input", handleCustomInput);
   });
-  toggleHardy.addEventListener("change", handleWoundsUpdate);
+  hardyTalent.addEventListener("input", handleWoundsUpdate);
   speciesSelect.addEventListener("change", handleWoundsUpdate);
   encumbranceSrc.forEach((item) => {
     item.addEventListener("input", handleEncumbrance);
@@ -423,10 +423,9 @@ document.addEventListener("DOMContentLoaded", (event) => {
       } else if (output.id === "toughness-bonus") {
         output.value = current * 2;
       } else if (output.id === "wounds") {
-        if (toggleHardy.checked) {
+        if (hardyTalent.value) {
           const toughness = document.getElementById("bonus-t");
-          const value =
-            toughness.value !== "" ? parseInt(toughness.value, 10) : 0;
+          const value = toughness.value !== "" ? parseInt(toughness.value, 10) * hardyTalent.value : 0;
           output.value = current + value;
         } else if (species.value === "halfling") {
           const strength = document.getElementById("bonus-s");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfrp-sheet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Online character sheet for Warhammer Fantasy Role Play TTRPG",
   "type": "module",
   "repository": {

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -3,32 +3,32 @@ export default {
     fr: "Feuille de personnage Warhammer Fantasy Role Play",
     en: "Warhammer Fantasy Role Play&apos;s character sheet",
     ru: "Лист персонажа Warhammer Fantasy Role Play",
-    pl: "Warhammer Fantasy Role Play: Karta Postaci"
+    pl: "Warhammer Fantasy Role Play: Karta Postaci",
   },
   desc: {
     fr: "Un outil en ligne pour gérer votre fiche de personnage pour le jeu de rôle Warhammer Fantasy Role Play",
     en: "An online tool to help you manage your Warhammer Fantasy Role Play game&apos;s character sheet",
     ru: "Онлайн инструмент для игры Warhammer Fantasy Role Play, который поможет в создании и редактировании листа персонажа",
-    pl: "Narzędzie online do zarządzania kartą postaci w Warhammer Fantasy Role Play"
+    pl: "Narzędzie online do zarządzania kartą postaci w Warhammer Fantasy Role Play",
   },
   h1: {
     fr: "Feuille de personnage",
     en: "Character sheet",
     ru: "Лист персонажа",
-    pl: "Karta Postaci"
+    pl: "Karta Postaci",
   },
   actions: {
     title: {
       fr: "Actions",
       en: "Actions",
       ru: "Действия",
-      pl: "Akcje"
+      pl: "Akcje",
     },
     delete: {
       fr: "Supprimer",
       en: "Delete",
       ru: "Удалить",
-      pl: "Usuń"
+      pl: "Usuń",
     },
   },
   info: {
@@ -36,19 +36,19 @@ export default {
       fr: "Informations du personnage",
       en: "Character&apos;s personal informations",
       ru: "Данные персонажа",
-      pl: "Informacje o postaci"
+      pl: "Informacje o postaci",
     },
     name: {
       fr: "Nom",
       en: "Name",
       ru: "Имя",
-      pl: "Imię"
+      pl: "Imię",
     },
     species: {
       fr: "Race",
       en: "Species",
       ru: "Раса",
-      pl: "Rasa"
+      pl: "Rasa",
     },
     speciesOptions: {
       human: {
@@ -98,55 +98,55 @@ export default {
       fr: "Classe",
       en: "Class",
       ru: "Класс",
-      pl: "Klasa"
+      pl: "Klasa",
     },
     career: {
       fr: "Carrière",
       en: "Career",
       ru: "Карьера",
-      pl: "Profesja"
+      pl: "Profesja",
     },
     careerTier: {
       fr: "Niveau de carrière",
       en: "Career Tier",
       ru: "Ступень карьеры",
-      pl: "Poziom profesji"
+      pl: "Poziom profesji",
     },
     careerPath: {
       fr: "Schéma de carrière",
       en: "Career Path",
       ru: "Карьерный путь",
-      pl: "Ścieżka profesji"
+      pl: "Ścieżka profesji",
     },
     status: {
       fr: "Statut",
       en: "Status",
       ru: "Статус",
-      pl: "Status"
+      pl: "Status",
     },
     age: {
       fr: "Âge",
       en: "Age",
       ru: "Возраст",
-      pl: "Wiek"
+      pl: "Wiek",
     },
     height: {
       fr: "Taille",
       en: "Height",
       ru: "Рост",
-      pl: "Wzrost"
+      pl: "Wzrost",
     },
     hair: {
       fr: "Cheveux",
       en: "Hair",
       ru: "Волосы",
-      pl: "Włosy"
+      pl: "Włosy",
     },
     eyes: {
       fr: "Yeux",
       en: "Eyes",
       ru: "Глаза",
-      pl: "Oczy"
+      pl: "Oczy",
     },
   },
   charac: {
@@ -154,26 +154,26 @@ export default {
       fr: "Caratéristiques",
       en: "Characteristics",
       ru: "Характеристики",
-      pl: "Cechy"
+      pl: "Cechy",
     },
     highlight: {
       fr: "Surligner cette caratéristique",
       en: "Highlight this characteristic",
       ru: "Подсветить характеристику",
-      pl: "Podświetl tą cechę"
+      pl: "Podświetl tą cechę",
     },
     ws: {
       full: {
         fr: "Corps à corps",
         en: "Weapon Skill",
         ru: "Ближний бой",
-        pl: "Walka Wręcz"
+        pl: "Walka Wręcz",
       },
       abbr: {
         fr: "CC",
         en: "WS",
         ru: "ББ",
-        pl: "WW"
+        pl: "WW",
       },
     },
     bs: {
@@ -181,13 +181,13 @@ export default {
         fr: "Capacité de tir",
         en: "Ballistic Skill",
         ru: "Дистанционный бой",
-        pl: "Umiejętności Strzeleckie"
+        pl: "Umiejętności Strzeleckie",
       },
       abbr: {
         fr: "CT",
         en: "BS",
         ru: "ДБ",
-        pl: "US"
+        pl: "US",
       },
     },
     s: {
@@ -195,13 +195,13 @@ export default {
         fr: "Force",
         en: "Strength",
         ru: "Сила",
-        pl: "Siła"
+        pl: "Siła",
       },
       abbr: {
         fr: "F",
         en: "S",
         ru: "С",
-        pl: "S"
+        pl: "S",
       },
     },
     t: {
@@ -209,13 +209,13 @@ export default {
         fr: "Endurance",
         en: "Toughness",
         ru: "Выносливость",
-        pl: "Wytrzymałość"
+        pl: "Wytrzymałość",
       },
       abbr: {
         fr: "E",
         en: "T",
         ru: "В",
-        pl: "Wt"
+        pl: "Wt",
       },
     },
     i: {
@@ -223,13 +223,13 @@ export default {
         fr: "Initiative",
         en: "Initiative",
         ru: "Инициатива",
-        pl: "Inicjatywa"
+        pl: "Inicjatywa",
       },
       abbr: {
         fr: "I",
         en: "I",
         ru: "И",
-        pl: "I"
+        pl: "I",
       },
     },
     ag: {
@@ -237,13 +237,13 @@ export default {
         fr: "Agilité",
         en: "Agility",
         ru: "Проворство",
-        pl: "Zwinność"
+        pl: "Zwinność",
       },
       abbr: {
         fr: "Ag",
         en: "Ag",
         ru: "Пр",
-        pl: "Zw"
+        pl: "Zw",
       },
     },
     dex: {
@@ -251,13 +251,13 @@ export default {
         fr: "Dextérité",
         en: "Dexterity",
         ru: "Ловкость",
-        pl: "Zręczność"
+        pl: "Zręczność",
       },
       abbr: {
         fr: "Dex",
         en: "Dex",
         ru: "Л",
-        pl: "Zr"
+        pl: "Zr",
       },
     },
     int: {
@@ -265,13 +265,13 @@ export default {
         fr: "Intelligence",
         en: "Intelligence",
         ru: "Интеллект",
-        pl: "Inteligencja"
+        pl: "Inteligencja",
       },
       abbr: {
         fr: "Int",
         en: "Int",
         ru: "Инт",
-        pl: "Int"
+        pl: "Int",
       },
     },
     wp: {
@@ -279,13 +279,13 @@ export default {
         fr: "Force mentale",
         en: "Will Power",
         ru: "Сила воли",
-        pl: "Siła Woli"
+        pl: "Siła Woli",
       },
       abbr: {
         fr: "FM",
         en: "WP",
         ru: "СВ",
-        pl: "SW"
+        pl: "SW",
       },
     },
     fel: {
@@ -293,32 +293,32 @@ export default {
         fr: "Social",
         en: "Fellowship",
         ru: "Харизма",
-        pl: "Ogłada"
+        pl: "Ogłada",
       },
       abbr: {
         fr: "Soc",
         en: "Fel",
         ru: "Х",
-        pl: "Ogd"
+        pl: "Ogd",
       },
     },
     initial: {
       fr: "Initiales",
       en: "Initial",
       ru: "Начальное значение",
-      pl: "Początkowa"
+      pl: "Początkowa",
     },
     advances: {
       fr: "Augmentation",
       en: "Advances",
       ru: "Шаги развития",
-      pl: "Rozwinięcia"
+      pl: "Rozwinięcia",
     },
     current: {
       fr: "Courantes",
       en: "Current",
       ru: "Текущее значение",
-      pl: "Aktualna"
+      pl: "Aktualna",
     },
   },
   points: {
@@ -327,19 +327,19 @@ export default {
         fr: "Destin",
         en: "Fate",
         ru: "Судьба",
-        pl: "Przeznaczenie"
+        pl: "Przeznaczenie",
       },
       availablePoints: {
         fr: "Points de destin disponibles",
         en: "Available fate points",
         ru: "Доступные очки судьбы",
-        pl: "Dostępne punkty przeznaczenie"
+        pl: "Dostępne punkty przeznaczenie",
       },
       totalPoints: {
         fr: "Points de destin total",
         en: "Total fate points",
         ru: "Всего очков судьбы",
-        pl: "Maksymalne punkty przeznaczenia"
+        pl: "Maksymalne punkty przeznaczenia",
       },
     },
     fortune: {
@@ -347,19 +347,19 @@ export default {
         fr: "Chance",
         en: "Fortune",
         ru: "Удача",
-        pl: "Szczęście"
+        pl: "Szczęście",
       },
       availablePoints: {
         fr: "Points de chance disponibles",
         en: "Available fortune points",
         ru: "Доступные очки удачи",
-        pl: "Dostępne punkty szczęścia"
+        pl: "Dostępne punkty szczęścia",
       },
       totalPoints: {
         fr: "Points de chance total",
         en: "Total fortune points",
         ru: "Всего очков удачи",
-        pl: "Maksymalne punkty szczęścia"
+        pl: "Maksymalne punkty szczęścia",
       },
     },
     resilience: {
@@ -367,25 +367,25 @@ export default {
         fr: "Résilience",
         en: "Resilience",
         ru: "Упорство",
-        pl: "Bohater"
+        pl: "Bohater",
       },
       abbr: {
         fr: "Rés.",
         en: "Resi.",
         ru: "Уп.",
-        pl: "Boh."
+        pl: "Boh.",
       },
       availablePoints: {
         fr: "Points de résilience disponibles",
         en: "Available resilience points",
         ru: "Доступные очки упорства",
-        pl: "Dostępne punkty bohatera"
+        pl: "Dostępne punkty bohatera",
       },
       totalPoints: {
         fr: "Points de résilience total",
         en: "Total resilience points",
         ru: "Всего очков упорства",
-        pl: "Maksymalne punkty bohatera"
+        pl: "Maksymalne punkty bohatera",
       },
     },
     resolve: {
@@ -393,25 +393,25 @@ export default {
         fr: "Détermination",
         en: "Resolve",
         ru: "Решимость",
-        pl: "Determinacja"
+        pl: "Determinacja",
       },
       abbr: {
         fr: "Déter.",
         en: "Reso.",
         ru: "Реш.",
-        pl: "Det."
+        pl: "Det.",
       },
       availablePoints: {
         fr: "Points de détermination disponibles",
         en: "Available resolve points",
         ru: "Доступные очки решимости",
-        pl: "Dostępne punkty determinacji"
+        pl: "Dostępne punkty determinacji",
       },
       totalPoints: {
         fr: "Points de détermination total",
         en: "Total resolve points",
         ru: "Всего очков решимости",
-        pl: "Maksymalne punkty determinacji"
+        pl: "Maksymalne punkty determinacji",
       },
     },
     motivation: {
@@ -419,13 +419,13 @@ export default {
         fr: "Motivation",
         en: "Motivation",
         ru: "Мотивация",
-        pl: "Motywacja"
+        pl: "Motywacja",
       },
       abbr: {
         fr: "Motiv.",
         en: "Motiv.",
         ru: "Мотив.",
-        pl: "Motyw."
+        pl: "Motyw.",
       },
     },
     experience: {
@@ -433,55 +433,55 @@ export default {
         fr: "Expérience",
         en: "Experience",
         ru: "Опыт",
-        pl: "Doświadczenie"
+        pl: "Doświadczenie",
       },
       current: {
         fr: "Actuelle",
         en: "Current",
         ru: "Запас",
-        pl: "Aktualne"
+        pl: "Aktualne",
       },
       currentAbbr: {
         fr: "Act.",
         en: "Cur.",
         ru: "Запас",
-        pl: "Akt."
+        pl: "Akt.",
       },
       currentLabel: {
         fr: "Expérience à dépenser",
         en: "Experience to spend",
         ru: "Непотраченные очки опыта",
-        pl: "Doświadczenie do wydania"
+        pl: "Doświadczenie do wydania",
       },
       spent: {
         fr: "Dépensée",
         en: "Spent",
         ru: "Потрачено",
-        pl: "Wydane"
+        pl: "Wydane",
       },
       spentAbbr: {
         fr: "Dép.",
         en: "Spe.",
         ru: "Траты",
-        pl: "Wyd."
+        pl: "Wyd.",
       },
       spentLabel: {
         fr: "Expérience dépensée",
         en: "Spent experience",
         ru: "Потрачено очков опыта",
-        pl: "Wydane doświadczenie"
+        pl: "Wydane doświadczenie",
       },
       total: {
         fr: "Totale",
         en: "Total",
         ru: "Всего очков опыта",
-        pl: "Suma"
+        pl: "Suma",
       },
       totalAbbr: {
         fr: "Tot.",
         en: "Tot.",
         ru: "Всего",
-        pl: "Sum."
+        pl: "Sum.",
       },
     },
   },
@@ -490,19 +490,19 @@ export default {
       fr: "Mouvement",
       en: "Movement",
       ru: "Перемещение",
-      pl: "Szybkość"
+      pl: "Szybkość",
     },
     walk: {
       fr: "Marche",
       en: "Walk",
       ru: "Шаг",
-      pl: "Chód"
+      pl: "Chód",
     },
     run: {
       fr: "Course",
       en: "Run",
       ru: "Бег",
-      pl: "Bieg"
+      pl: "Bieg",
     },
   },
   skills: {
@@ -510,61 +510,61 @@ export default {
       fr: "Compétences de base",
       en: "Basic skills",
       ru: "Общие навыки",
-      pl: "Umiejętności podstawowe"
+      pl: "Umiejętności podstawowe",
     },
     customTitle: {
       fr: "Compétences avancées",
       en: "Advanced skills",
       ru: "Профессиональные навыки",
-      pl: "Umiejętności zaawansowane"
+      pl: "Umiejętności zaawansowane",
     },
     name: {
       fr: "Nom",
       en: "Name",
       ru: "Навык",
-      pl: "Nazwa"
+      pl: "Nazwa",
     },
     charac: {
       fr: "Caractéristique",
       en: "Characteristic",
       ru: "Характеристика",
-      pl: "Cecha"
+      pl: "Cecha",
     },
     characAbbr: {
       fr: "Carac.",
       en: "Charac.",
       ru: "Хар.",
-      pl: "Cecha"
+      pl: "Cecha",
     },
     adv: {
       fr: "Augmentation",
       en: "Advance",
       ru: "Шаги развития",
-      pl: "Rozwinięcia"
+      pl: "Rozwinięcia",
     },
     advAbbr: {
       fr: "Aug.",
       en: "Adv.",
       ru: "Шаги",
-      pl: "Roz."
+      pl: "Roz.",
     },
     skill: {
       fr: "Compétence",
       en: "Skill",
       ru: "Значение",
-      pl: "Suma"
+      pl: "Suma",
     },
     skillAbbr: {
       fr: "Comp.",
       en: "Skill",
       ru: "Знач.",
-      pl: "Suma"
+      pl: "Suma",
     },
     highlight: {
       fr: "Surligner cette compétence",
       en: "Highlight this skill",
       ru: "Подсветить навык",
-      pl: "Oznacz tą umiejętność"
+      pl: "Oznacz tą umiejętność",
     },
     basic: [
       {
@@ -574,7 +574,7 @@ export default {
           fr: "Art",
           en: "Art",
           ru: "Искусство",
-          pl: "Sztuka"
+          pl: "Sztuka",
         },
       },
       {
@@ -584,7 +584,7 @@ export default {
           fr: "Athlétisme",
           en: "Athletics",
           ru: "Атлетика",
-          pl: "Atletyka"
+          pl: "Atletyka",
         },
       },
       {
@@ -594,7 +594,7 @@ export default {
           fr: "Calme",
           en: "Cool",
           ru: "Хладнокровие",
-          pl: "Opanowanie"
+          pl: "Opanowanie",
         },
       },
       {
@@ -604,7 +604,7 @@ export default {
           fr: "Charme",
           en: "Charm",
           ru: "Обаяние",
-          pl: "Charyzma"
+          pl: "Charyzma",
         },
       },
       {
@@ -614,7 +614,7 @@ export default {
           fr: "Chevaucher",
           en: "Ride",
           ru: "Верховая езда",
-          pl: "Jeździectwo"
+          pl: "Jeździectwo",
         },
       },
       {
@@ -624,7 +624,7 @@ export default {
           fr: "Commandement",
           en: "Leadership",
           ru: "Лидерство",
-          pl: "Dowodzenie"
+          pl: "Dowodzenie",
         },
       },
       {
@@ -634,7 +634,7 @@ export default {
           fr: "Conduite d&apos;attelage",
           en: "Drive",
           ru: "Вождение",
-          pl: "Powożenie"
+          pl: "Powożenie",
         },
       },
       {
@@ -644,7 +644,7 @@ export default {
           fr: "Corps à corps (base)",
           en: "Melee (Basic)",
           ru: "Рукопашный бой (осн.)",
-          pl: "Broń Biała (Podstawowa)"
+          pl: "Broń Biała (Podstawowa)",
         },
       },
       {
@@ -654,7 +654,7 @@ export default {
           fr: "Corps à corps",
           en: "Melee",
           ru: "Рукопашный бой",
-          pl: "Broń Biała"
+          pl: "Broń Biała",
         },
       },
       {
@@ -664,7 +664,7 @@ export default {
           fr: "Discrétion",
           en: "Stealth",
           ru: "Скрытность",
-          pl: "Skradanie"
+          pl: "Skradanie",
         },
       },
       {
@@ -674,7 +674,7 @@ export default {
           fr: "Divertissement",
           en: "Entertain",
           ru: "Артистизм",
-          pl: "Występy"
+          pl: "Występy",
         },
       },
       {
@@ -684,7 +684,7 @@ export default {
           fr: "Emprise animaux",
           en: "Charm Animal",
           ru: "Усмирение животных",
-          pl: "Oswajanie"
+          pl: "Oswajanie",
         },
       },
       {
@@ -694,7 +694,7 @@ export default {
           fr: "Escalade",
           en: "Climb",
           ru: "Лазание",
-          pl: "Wspinaczka"
+          pl: "Wspinaczka",
         },
       },
       {
@@ -704,7 +704,7 @@ export default {
           fr: "Esquive",
           en: "Dodge",
           ru: "Уклонение",
-          pl: "Unik"
+          pl: "Unik",
         },
       },
       {
@@ -714,7 +714,7 @@ export default {
           fr: "Intimidation",
           en: "Intimidate",
           ru: "Запугивание",
-          pl: "Zastraszanie"
+          pl: "Zastraszanie",
         },
       },
       {
@@ -724,7 +724,7 @@ export default {
           fr: "Intuition",
           en: "Intuition",
           ru: "Интуиция",
-          pl: "Intuicja"
+          pl: "Intuicja",
         },
       },
       {
@@ -734,7 +734,7 @@ export default {
           fr: "Marchandage",
           en: "Haggle",
           ru: "Торговля",
-          pl: "Targowanie"
+          pl: "Targowanie",
         },
       },
       {
@@ -744,7 +744,7 @@ export default {
           fr: "Orientation",
           en: "Navigation",
           ru: "Ориентирование",
-          pl: "Nawigacja"
+          pl: "Nawigacja",
         },
       },
       {
@@ -754,7 +754,7 @@ export default {
           fr: "Pari",
           en: "Gamble",
           ru: "Азартные игры",
-          pl: "Hazard"
+          pl: "Hazard",
         },
       },
       {
@@ -764,7 +764,7 @@ export default {
           fr: "Perception",
           en: "Perception",
           ru: "Наблюдательность",
-          pl: "Percepcja"
+          pl: "Percepcja",
         },
       },
       {
@@ -774,7 +774,7 @@ export default {
           fr: "Ragot",
           en: "Gossip",
           ru: "Сплетничество",
-          pl: "Plotkowanie"
+          pl: "Plotkowanie",
         },
       },
       {
@@ -784,7 +784,7 @@ export default {
           fr: "Ramer",
           en: "Row",
           ru: "Гребля",
-          pl: "Wioślarstwo"
+          pl: "Wioślarstwo",
         },
       },
       {
@@ -794,7 +794,7 @@ export default {
           fr: "Résistance",
           en: "Endurance",
           ru: "Стойкость",
-          pl: "Odporność"
+          pl: "Odporność",
         },
       },
       {
@@ -804,7 +804,7 @@ export default {
           fr: "Résistance à l&apos;alcool",
           en: "Consume Alcohol",
           ru: "Кутеж",
-          pl: "Mocna głowa"
+          pl: "Mocna głowa",
         },
       },
       {
@@ -814,7 +814,7 @@ export default {
           fr: "Subordination",
           en: "Bribery",
           ru: "Подкуп",
-          pl: "Przekupstwo"
+          pl: "Przekupstwo",
         },
       },
       {
@@ -824,7 +824,7 @@ export default {
           fr: "Survie en extérieur",
           en: "Outdoor Survival",
           ru: "Выживание",
-          pl: "Sztuka Przetrwania"
+          pl: "Sztuka Przetrwania",
         },
       },
     ],
@@ -832,7 +832,7 @@ export default {
       fr: "Caractéristique de base",
       en: "Based on characteristic",
       ru: "На основе характеристик",
-      pl: "Podstawa"
+      pl: "Podstawa",
     },
   },
   talents: {
@@ -840,37 +840,37 @@ export default {
       fr: "Talents",
       en: "Talents",
       ru: "Таланты",
-      pl: "Talenty"
+      pl: "Talenty",
     },
     name: {
       fr: "Nom du talent",
       en: "Talent Name",
       ru: "Талант",
-      pl: "Talent"
+      pl: "Talent",
     },
     taken: {
       fr: "Nombre de fois pris",
       en: "Times Taken",
       ru: "Уровень",
-      pl: "Poziom talentu"
+      pl: "Poziom talentu",
     },
     takenAbbr: {
       fr: "Nbre pris",
       en: "Taken",
       ru: "Уровень",
-      pl: "Poziom"
+      pl: "Poziom",
     },
     desc: {
       fr: "Description",
       en: "Description",
       ru: "Описание",
-      pl: "Opis"
+      pl: "Opis",
     },
     highlight: {
       fr: "Surligner ce talent",
       en: "Highlight this talent",
       ru: "Подсветить талант",
-      pl: "Oznacz ten talent"
+      pl: "Oznacz ten talent",
     },
   },
   ambitions: {
@@ -878,19 +878,19 @@ export default {
       fr: "Ambitions",
       en: "Ambitions",
       ru: "Амбиции",
-      pl: "Ambicje"
+      pl: "Ambicje",
     },
     short: {
       fr: "À court terme",
       en: "Short Term",
       ru: "Краткосрочная",
-      pl: "Ambicja krótkoterminowa"
+      pl: "Ambicja krótkoterminowa",
     },
     long: {
       fr: "À long terme",
       en: "Long Term",
       ru: "Долгосрочная",
-      pl: "Ambicja długoterminowa"
+      pl: "Ambicja długoterminowa",
     },
   },
   party: {
@@ -898,31 +898,31 @@ export default {
       fr: "Groupe",
       en: "Party",
       ru: "Команда",
-      pl: "Drużyna"
+      pl: "Drużyna",
     },
     name: {
       fr: "Nom du groupe",
       en: "Party Name",
       ru: "Название команды",
-      pl: "Nazwa drużyny"
+      pl: "Nazwa drużyny",
     },
     short: {
       fr: "À court terme",
       en: "Short Term",
       ru: "Краткосрочная амбиция",
-      pl: "Ambicja drużynowa krótkoterminowa"
+      pl: "Ambicja drużynowa krótkoterminowa",
     },
     long: {
       fr: "À long terme",
       en: "Long Term",
       ru: "Долгосрочная амбиция",
-      pl: "Ambicja drużynowa długoterminowa"
+      pl: "Ambicja drużynowa długoterminowa",
     },
     members: {
       fr: "Membres",
       en: "Members",
       ru: "Члены команды",
-      pl: "Członkowie drużyny"
+      pl: "Członkowie drużyny",
     },
   },
   armour: {
@@ -930,55 +930,55 @@ export default {
       fr: "Armure",
       en: "Armour",
       ru: "Броня",
-      pl: "Pancerz"
+      pl: "Pancerz",
     },
     name: {
       fr: "Nom",
       en: "Name",
       ru: "Название",
-      pl: "Nazwa"
+      pl: "Nazwa",
     },
     locations: {
       fr: "Localisation",
       en: "Locations",
       ru: "Зоны попадания",
-      pl: "Lokacja"
+      pl: "Lokacja",
     },
     encumbrance: {
       fr: "Encombrement",
       en: "Encumbrance",
       ru: "Вес",
-      pl: "Obciążenie"
+      pl: "Obciążenie",
     },
     encumbranceAbbr: {
       fr: "Enc",
       en: "Enc",
       ru: "Вес",
-      pl: "Obc"
+      pl: "Obc",
     },
     points: {
       fr: "Points d&apos;armure",
       en: "Armour Points",
       ru: "Класс брони",
-      pl: "Punkty Pancerza"
+      pl: "Punkty Pancerza",
     },
     pointsAbbr: {
       fr: "PA",
       en: "AP",
       ru: "КБ",
-      pl: "PP"
+      pl: "PP",
     },
     qualities: {
       fr: "Atouts/Défauts",
       en: "Qualities",
       ru: "Качества",
-      pl: "Cechy"
+      pl: "Cechy",
     },
     worn: {
       fr: "Porté",
       en: "Worn",
       ru: "Снаряжен",
-      pl: "Założony"
+      pl: "Założony",
     },
   },
   armourPoints: {
@@ -986,49 +986,49 @@ export default {
       fr: "Points d&apos;armure (PA)",
       en: "Armour Points (AP)",
       ru: "Класс брони (КБ)",
-      pl: "Punkty Pancerza (PP)"
+      pl: "Punkty Pancerza (PP)",
     },
     head: {
       fr: "Tête",
       en: "Head",
       ru: "Голова",
-      pl: "Głowa"
+      pl: "Głowa",
     },
     rightArm: {
       fr: "Bras fort",
       en: "Right Arm",
       ru: "Правая рука",
-      pl: "Prawa ręka"
+      pl: "Prawa ręka",
     },
     leftArm: {
       fr: "Bras faible",
       en: "Left Arm",
       ru: "Левая рука",
-      pl: "Lewa ręka"
+      pl: "Lewa ręka",
     },
     body: {
       fr: "Corps",
       en: "Body",
       ru: "Торс",
-      pl: "Korpus"
+      pl: "Korpus",
     },
     rightLeg: {
       fr: "Jambe droite",
       en: "Right Leg",
       ru: "Правая нога",
-      pl: "Prawa noga"
+      pl: "Prawa noga",
     },
     leftLeg: {
       fr: "Jambe gauche",
       en: "Left Leg",
       ru: "Левая нога",
-      pl: "Lewa noga"
+      pl: "Lewa noga",
     },
     shield: {
       fr: "Bouclier",
       en: "Shield",
       ru: "Щит",
-      pl: "Tarcza"
+      pl: "Tarcza",
     },
   },
   wounds: {
@@ -1036,61 +1036,61 @@ export default {
       fr: "Blessures",
       en: "Wounds",
       ru: "Здоровье",
-      pl: "Żywotność"
+      pl: "Żywotność",
     },
     strengthBonus: {
       fr: "Bonus de Force",
       en: "Strength Bonus",
       ru: "Рейтинг Силы",
-      pl: "Bonus z Siły"
+      pl: "Bonus z Siły",
     },
     strengthBonusAbbr: {
       fr: "BF",
       en: "SB",
       ru: "РС",
-      pl: "BS"
+      pl: "BS",
     },
     toughnessBonus: {
       fr: "Bonus de d&apos;Endurance fois deux",
       en: "Toughness Bonus times two",
       ru: "Рейтинг Выносилвости помноженный на два",
-      pl: "Podwojony bonus z Wytrzymałości"
+      pl: "Podwojony bonus z Wytrzymałości",
     },
     toughnessBonusAbbr: {
       fr: "BEx2",
       en: "TBx2",
       ru: "РВх2",
-      pl: "BWtx2"
+      pl: "BWtx2",
     },
     willPowerBonus: {
       fr: "Bonus de Force Mentale",
       en: "Will Power Bonus",
       ru: "Рейтинг Силы Воли",
-      pl: "Bonus z Siły Woli"
+      pl: "Bonus z Siły Woli",
     },
     willPowerBonusAbbr: {
       fr: "BFM",
       en: "WPB",
       ru: "РСВ",
-      pl: "BSW"
+      pl: "BSW",
     },
     hardy: {
-      fr: "Dur à cuire",
-      en: "Hardy",
-      ru: "Здоровяк",
-      pl: "Twardziel"
+      fr: "Niveau Dur à cuire",
+      en: "Hardy level",
+      ru: "Здоровяк (ур.)",
+      pl: "Twardziel (Poz)",
     },
     hardyLabel: {
-      fr: "Talent Dur à cuire",
-      en: "Hardy Talent",
-      ru: "Талант Здоровяк",
-      pl: "Talent Twardziel"
+      fr: "Niveau du talent Dur à cuire",
+      en: "Hardy Talent level",
+      ru: "Уровень таланта Здоровяк",
+      pl: "Poziom talentu Twardziel",
     },
     current: {
       fr: "Points de blessure actuels",
       en: "Current wounds",
       ru: "Пункты здоровья",
-      pl: "Aktualne rany"
+      pl: "Aktualne rany",
     },
   },
   trappings: {
@@ -1098,31 +1098,31 @@ export default {
       fr: "Possessions",
       en: "Trappings",
       ru: "Имущество",
-      pl: "Wyposażenie"
+      pl: "Wyposażenie",
     },
     name: {
       fr: "Nom",
       en: "Name",
       ru: "Название",
-      pl: "Nazwa"
+      pl: "Nazwa",
     },
     encumbrance: {
       fr: "Encombrement",
       en: "Encumbrance",
       ru: "Вес",
-      pl: "Obiążenie"
+      pl: "Obiążenie",
     },
     encumbranceAbbr: {
       fr: "Enc",
       en: "Enc",
       ru: "Вес",
-      pl: "Obc"
+      pl: "Obc",
     },
     worn: {
       fr: "Porté",
       en: "Worn",
       ru: "Снаряжен",
-      pl: "Założone"
+      pl: "Założone",
     },
   },
   encumbrance: {
@@ -1130,50 +1130,50 @@ export default {
       fr: "Encombrement",
       en: "Encumbrance",
       ru: "Вес",
-      pl: "Obiążenie"
+      pl: "Obiążenie",
     },
     weapons: {
       fr: "Armes",
       en: "Weapons",
       ru: "Оружие",
-      pl: "Broń"
+      pl: "Broń",
     },
     armour: {
       fr: "Armures",
       en: "Armour",
       ru: "Броня",
-      pl: "Pancerz"
+      pl: "Pancerz",
     },
     trappings: {
       fr: "Possessions",
       en: "Trappings",
       ru: "Имущество",
-      pl: "Wyposażenie"
+      pl: "Wyposażenie",
     },
     max: {
       fr: "Encombrement maximum",
       en: "Maximum Encumbrance",
       ru: "Максимальное значение веса",
-      pl: "Maksymalne Obciążenie"
+      pl: "Maksymalne Obciążenie",
     },
     maxAbbr: {
       fr: "Enc. max",
       en: "Max Enc.",
       ru: "Макс вес",
-      pl: "Max Obc"
+      pl: "Max Obc",
     },
     total: {
       fr: "Total",
       en: "Total",
       ru: "Общий вес",
-      pl: "Suma"
+      pl: "Suma",
     },
     penalty0: {
       title: {
         fr: "Pas de pénalité",
         en: "No penalty",
         ru: "Без штрафов",
-        pl: "Kara"
+        pl: "Kara",
       },
     },
     penalty1: {
@@ -1181,25 +1181,25 @@ export default {
         fr: "Surchargé Niv. 1",
         en: "Overburdened Lvl 1",
         ru: "Перегружен Ур. 1",
-        pl: "Przeciążony Poz 1"
+        pl: "Przeciążony Poz 1",
       },
       p1: {
         fr: "-1 mouvement (Min: 3)",
         en: "-1 Movement (Min: 3)",
         ru: "-1 Перемещение (Мин: 3)",
-        pl: "-1 Szybkość (Min: 3)"
+        pl: "-1 Szybkość (Min: 3)",
       },
       p2: {
         fr: "-10 en agilité",
         en: "-10 Agility",
         ru: "-10 Ловкость",
-        pl: "-10 Zwinność"
+        pl: "-10 Zwinność",
       },
       p3: {
         fr: "+1 fatigue du voyage",
         en: "+1 Travel Fatigue",
         ru: "+1 усталость",
-        pl: "+1 Zmęczenie podróżą"
+        pl: "+1 Zmęczenie podróżą",
       },
     },
     penalty2: {
@@ -1207,25 +1207,25 @@ export default {
         fr: "Surchargé Niv. 2",
         en: "Overburdened Lvl 2",
         ru: "Перегружен Ур. 2",
-        pl: "Przeciążony Poz 2"
+        pl: "Przeciążony Poz 2",
       },
       p1: {
         fr: "-2 mouvement (Min: 3)",
         en: "-2 Movement (Min: 3)",
         ru: "-2 Перемещение (Мин: 3)",
-        pl: "-2 Szybkość (Min: 3)"
+        pl: "-2 Szybkość (Min: 3)",
       },
       p2: {
         fr: "-20 en agilité",
         en: "-20 Agility",
         ru: "-20 Ловкость",
-        pl: "-20 Zwinność"
+        pl: "-20 Zwinność",
       },
       p3: {
         fr: "+2 fatigue du voyage",
         en: "+2 Travel Fatigue",
         ru: "+2 Усталось",
-        pl: "+2 Zmęczenie podróżą"
+        pl: "+2 Zmęczenie podróżą",
       },
     },
     penalty3: {
@@ -1233,13 +1233,13 @@ export default {
         fr: "Surchargé Niv. 3",
         en: "Overburdened Lvl 3",
         ru: "Перегружен Ур 3",
-        pl: "Przeciążony Poz 3"
+        pl: "Przeciążony Poz 3",
       },
       p1: {
         fr: "Vous ne pouvez plus vous déplacer",
         en: "You&apos;re not moving",
         ru: "Без движения",
-        pl: "Nie możesz się poruszać"
+        pl: "Nie możesz się poruszać",
       },
     },
   },
@@ -1248,49 +1248,49 @@ export default {
       fr: "Richesses",
       en: "Wealth",
       ru: "Деньги",
-      pl: "Zamożność"
+      pl: "Zamożność",
     },
     copper: {
       fr: "Sous de cuivre",
       en: "Brass Pennies",
       ru: "Медные Пенни",
-      pl: "Brązowe Pensy"
+      pl: "Brązowe Pensy",
     },
     copperAbbr: {
       fr: "sc",
       en: "D",
       ru: "Медь",
-      pl: "P"
+      pl: "P",
     },
     silver: {
       fr: "Pistoles d&apos;argent",
       en: "Silver Schilings",
       ru: "Серебряные Шиллинги",
-      pl: "Srebrne Szylingi"
+      pl: "Srebrne Szylingi",
     },
     silverAbbr: {
       fr: "/-",
       en: "SS",
       ru: "Серебро",
-      pl: "S"
+      pl: "S",
     },
     gold: {
       fr: "Couronnes d&apos;or",
       en: "Gold Crowns",
       ru: "Золотые Кроны",
-      pl: "Złote Korony"
+      pl: "Złote Korony",
     },
     goldAbbr: {
       fr: "CO",
       en: "GC",
       ru: "Золото",
-      pl: "ZK"
+      pl: "ZK",
     },
     change: {
       fr: "1CO = 20/- = 240sc",
       en: "1GC = 20SS = 240D",
       ru: "1 Золотой = 20 Серебряных = 240 Медных",
-      pl: "1ZK = 20S = 240P"
+      pl: "1ZK = 20S = 240P",
     },
   },
   psychology: {
@@ -1298,7 +1298,7 @@ export default {
       fr: "Psychologie",
       en: "Psychology",
       ru: "Психология",
-      pl: "Psychologia"
+      pl: "Psychologia",
     },
   },
   corruption: {
@@ -1306,25 +1306,25 @@ export default {
       fr: "Corruption et mutation",
       en: "Corruption & mutation",
       ru: "Скверна и Мутации",
-      pl: "Zepsucie i Mutacje"
+      pl: "Zepsucie i Mutacje",
     },
     threshold: {
       fr: "Seuil",
       en: "Threshold",
       ru: "Порог",
-      pl: "Limit"
+      pl: "Limit",
     },
     points: {
       fr: "Points de corruption",
       en: "Current Corruption",
       ru: "Очки скверны",
-      pl: "Punkty Zepsucia"
+      pl: "Punkty Zepsucia",
     },
     mutations: {
       fr: "Mutations",
       en: "Mutations",
       ru: "Мутации",
-      pl: "Mutacje"
+      pl: "Mutacje",
     },
   },
   weapons: {
@@ -1332,55 +1332,55 @@ export default {
       fr: "Armes",
       en: "Weapons",
       ru: "Оружие",
-      pl: "Broń"
+      pl: "Broń",
     },
     name: {
       fr: "Nom",
       en: "Name",
       ru: "Название",
-      pl: "Nazwa"
+      pl: "Nazwa",
     },
     group: {
       fr: "Groupe",
       en: "Group",
       ru: "Тип",
-      pl: "Kategoria"
+      pl: "Kategoria",
     },
     encumbrance: {
       fr: "Encombrement",
       en: "Encumbrance",
       ru: "Вес",
-      pl: "Obiążenie"
+      pl: "Obiążenie",
     },
     encumbranceAbbr: {
       fr: "Enc",
       en: "Enc",
       ru: "Вес",
-      pl: "Obc"
+      pl: "Obc",
     },
     range: {
       fr: "Portée/Allonge",
       en: "Range/Reach",
       ru: "Длина/Дальность",
-      pl: "Zasięg"
+      pl: "Zasięg",
     },
     damage: {
       fr: "Dégâts",
       en: "Damage",
       ru: "Урон",
-      pl: "Obrażenia"
+      pl: "Obrażenia",
     },
     qualities: {
       fr: "Atouts/Défauts",
       en: "Qualities",
       ru: "Качества",
-      pl: "Cechy"
+      pl: "Cechy",
     },
     worn: {
       fr: "Porté",
       en: "Worn",
       ru: "Снаряжен",
-      pl: "Wyposażona"
+      pl: "Wyposażona",
     },
   },
   spells: {
@@ -1388,55 +1388,55 @@ export default {
       fr: "Sorts et prières",
       en: "Spells & Prayers",
       ru: "Заклинания и Молитвы",
-      pl: "Czary i Modlitwy"
+      pl: "Czary i Modlitwy",
     },
     name: {
       fr: "Nom",
       en: "Name",
       ru: "Название",
-      pl: "Nazwa"
+      pl: "Nazwa",
     },
     cn: {
       fr: "Niveau d&apos;incantation",
       en: "Cast Number",
       ru: "Порог Сотворения",
-      pl: "Poziom Czaru"
+      pl: "Poziom Czaru",
     },
     cnAbbr: {
       fr: "NI",
       en: "CN",
       ru: "ПС",
-      pl: "PC"
+      pl: "PC",
     },
     range: {
       fr: "Portée",
       en: "Range",
       ru: "Дальность",
-      pl: "Zasięg"
+      pl: "Zasięg",
     },
     target: {
       fr: "Cible",
       en: "Target",
       ru: "Цель",
-      pl: "Cel"
+      pl: "Cel",
     },
     duration: {
       fr: "Durée",
       en: "Duration",
       ru: "Длительность",
-      pl: "Czas trwania"
+      pl: "Czas trwania",
     },
     effects: {
       fr: "Effets",
       en: "Effect",
       ru: "Эффект",
-      pl: "Efekt"
+      pl: "Efekt",
     },
     sin: {
       fr: "Péché",
       en: "Sin",
       ru: "Грех",
-      pl: "Punkty Grzechu"
+      pl: "Punkty Grzechu",
     },
   },
   settings: {
@@ -1444,13 +1444,13 @@ export default {
       fr: "Paramètres",
       en: "Settings",
       ru: "Настройки",
-      pl: "Ustawienia"
+      pl: "Ustawienia",
     },
     close: {
       fr: "Fermer",
       en: "Close",
       ru: "Закрыть",
-      pl: "Zamknij"
+      pl: "Zamknij",
     },
     open: {
       fr: "Ouvrir les paramètres",
@@ -1463,31 +1463,31 @@ export default {
         fr: "Choisir mon thème",
         en: "Choose my theme",
         ru: "Выбрать оформление",
-        pl: "Wybierz motyw"
+        pl: "Wybierz motyw",
       },
       light: {
         fr: "Clair",
         en: "Light",
         ru: "Светлая",
-        pl: "Jasny"
+        pl: "Jasny",
       },
       dark: {
         fr: "Foncé",
         en: "Dark",
         ru: "Темная",
-        pl: "Ciemny"
+        pl: "Ciemny",
       },
       auto: {
         fr: "Auto",
         en: "Auto",
         ru: "Автоматически",
-        pl: "Auto"
+        pl: "Auto",
       },
       notice: {
         fr: 'Le choix "auto" s&apos;affichera selon la préférence paramétrée dans votre système d&apos;exploitation.',
         en: "Auto option will rely on your operating system&apos;s settings.",
         ru: "Автоматическое оформление будет зависеть от настроек системы.",
-        pl: "Opcja 'auto' jest zależna od ustawienia w systemie operacyjnym."
+        pl: "Opcja 'auto' jest zależna od ustawienia w systemie operacyjnym.",
       },
     },
     export: {
@@ -1495,19 +1495,19 @@ export default {
         fr: "Exporter mes données locales",
         en: "Export my local data",
         ru: "Экспорт локальный данных",
-        pl: "Eksportuj dane"
+        pl: "Eksportuj dane",
       },
       button: {
         fr: "Télécharger mes données",
         en: "Download my data",
         ru: "Скачать мои данные",
-        pl: "Pobierz dane"
+        pl: "Pobierz dane",
       },
       notice: {
         fr: "Le fichier d&apos;export sera au format <strong>.json</strong>.<br>Les données locales ne seront pas supprimées.",
         en: "The export file will have a <strong>.json</strong> format.<br>Local data will not be deleted.",
         ru: "Данные будут сохранены в формате <strong>.json</strong>.<br>Локальные даные не будут удалены.",
-        pl: "Eksportujesz dane do formatu <strong>.json</strong>. Dane nie zostaną usunięte z przeglądarki."
+        pl: "Eksportujesz dane do formatu <strong>.json</strong>. Dane nie zostaną usunięte z przeglądarki.",
       },
     },
     import: {
@@ -1515,13 +1515,13 @@ export default {
         fr: "Import mes données",
         en: "Import my data",
         ru: "Импортировать мои данные",
-        pl: "Importuj dane"
+        pl: "Importuj dane",
       },
       button: {
         fr: "Envoyer",
         en: "Send",
         ru: "Отправить",
-        pl: "Wyślij"
+        pl: "Wyślij",
       },
       notice: {
         fr: "⚠️ Importer des données écrasera toute donnée actuellement enregistrée localement.",
@@ -1533,25 +1533,25 @@ export default {
         fr: "Données importées. 🎉",
         en: "Data imported. 🎉",
         ru: "Данные импортированы. 🎉",
-        pl: "Dane zaimportowane. 🎉"
+        pl: "Dane zaimportowane. 🎉",
       },
       errorEmpty: {
         fr: "Aucun fichier selectionné.",
         en: "No file selected",
         ru: "Файл не выбран",
-        pl: "Nie wybrano żadnego pliku"
+        pl: "Nie wybrano żadnego pliku",
       },
       errorFile: {
         fr: "Le fichier doit être un fichier JSON.",
         en: "The data file must be a JSON file",
         ru: "Формат файла с данными должен быть JSON",
-        pl: "Plik danych musi być w formacie JSON."
+        pl: "Plik danych musi być w formacie JSON.",
       },
       error: {
         fr: "Une erreur est survenue. Vérifiez que vous avez bien fourni un fichier JSON provenant de l&apos;app et, le cas échéant, contactez l&apos;administrateur.",
         en: "An error occurred. Check that you have provided a JSON file from the app and, if so, contact the admin.",
         ru: "Произошла ошибка. Проверьте что вы предоставили файл из этого приложения в формате JSON, если все корректно - свяжитесь с администрацией.",
-        pl: "Wystąpił błąd. Sprawdź, czy wybrałeś plik eksportowany z aplikacji. Jeżeli tak, skontaktuj się z administratorem."
+        pl: "Wystąpił błąd. Sprawdź, czy wybrałeś plik eksportowany z aplikacji. Jeżeli tak, skontaktuj się z administratorem.",
       },
     },
     version: {
@@ -1559,25 +1559,25 @@ export default {
         fr: "Version",
         en: "Version",
         ru: "Версия",
-        pl: "Wersja"
+        pl: "Wersja",
       },
       desc: {
         fr: "Version actuelle :",
         en: "Current version:",
         ru: "Текущая версия:",
-        pl: "Aktualna wersja:"
+        pl: "Aktualna wersja:",
       },
       more: {
         fr: "Cliquez sur le lien dessous pour plus d&apos;informations",
         en: "Click on the link below for more information",
         ru: "Чтобы ознакомиться с подробностями нажмите на ссылку ниже",
-        pl: "Kliknij w poniższy link po więcej informacji"
+        pl: "Kliknij w poniższy link po więcej informacji",
       },
       link: {
         fr: "Lire le CHANGELOG.md (en anglais)",
         en: "Read the CHANGELOG.md",
         ru: "Прочитать CHANGELOG.md (янгл. язык)",
-        pl: "Przeczytaj plik CHANGELOG.md (po angielsku)"
+        pl: "Przeczytaj plik CHANGELOG.md (po angielsku)",
       },
     },
   },

--- a/src/_includes/sheet.html
+++ b/src/_includes/sheet.html
@@ -940,7 +940,7 @@
                 <th scope="row" class="narrow">{{ 'wounds.hardy' | i18n }}</th>
                 <td>
                   <label class="sr-only" for="hardy-bonus">{{ 'wounds.hardyLabel' | i18n }}</label>
-                  <input type="checkbox" name="hardy-bonus" id="hardy-bonus" value="hardy bonus">
+                  <input type="number" name="hardy-bonus" id="hardy-bonus">
                 </td>
               </tr>
               <tr>

--- a/tests/wounds.spec.cjs
+++ b/tests/wounds.spec.cjs
@@ -24,10 +24,10 @@ test('should update wounds values according to charac values with Hardy talent b
   await page.locator('#wp-i').fill('35');
 
   // Check Hardy talent's bonus
-  await page.locator('#hardy-bonus').check();
+  await page.locator('#hardy-bonus').fill('2');
 
   // Toughness bonus should be added
-  await expect(page.locator('#wounds')).toHaveText('15');
+  await expect(page.locator('#wounds')).toHaveText('18');
 });
 
 test('should update wounds values if species chosen is halfling', async ({ page }) => {


### PR DESCRIPTION
Before you were allow only one level of the talent Hardy.
I made some adjustments to allow multiple level of Hardy.

I also added the "level" notion in the UI so the user can understand what is expected in the field: the level number, not the hit point addition.

@starp0m @Kryszak Would you be kind enough to tell me what labels would be best in this case ? (I tried to translate by myself but failed dramatically :D)
I renamed `Hardy` to `Hardy level` and `Hardy talent` to `Hardy talent level`. (see the diff for more details)
Just leave a comment on this PR, no need for you to create a new one.